### PR TITLE
Add support for extracting call stack from execution sequence.

### DIFF
--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -49,7 +49,7 @@ class Cdl:
         elif currLog.type == LINE_TYPE["VARIABLE"]:
             self.execution.append(currLog)
 
-    def addToCallStack(self, logType):
+    def addToCallStack(self, ltId):
         '''
             Add the current execution to the call stack.
 
@@ -60,7 +60,7 @@ class Cdl:
             - Copy stack into global list            
         '''
         position = len(self.execution) - 1
-        ltInfo = self.header.getLtInfo(logType)
+        ltInfo = self.header.getLtInfo(ltId)
         cs = self.callStack
 
         if (ltInfo.isFunction()):
@@ -73,10 +73,10 @@ class Cdl:
             cs.pop()
 
         # Update the call stack to indicate where the functions were called from.
-        csMapped = list(map(self.getPreviousPosition, self.callStack) )
-        csMapped.append(position)
+        csFromCallPosition = list(map(self.getPreviousPosition, self.callStack) )
+        csFromCallPosition.append(position)
 
-        self.callStacks.append(csMapped.copy())
+        self.callStacks.append(csFromCallPosition)
     
     def getPreviousPosition(self, position):
         '''

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -16,6 +16,8 @@ class Cdl:
         self.execution = []
         self.exception = None
         self.uniqueids = []
+        self.callStack = []
+        self.callStacks = []
 
         self.loadAndParseFile(fileName)
 
@@ -41,10 +43,54 @@ class Cdl:
             self.exception = currLog.value
         elif currLog.type == LINE_TYPE["EXECUTION"]:
             self.execution.append(currLog)
+            self.addToCallStack(currLog.ltId)
         elif currLog.type == LINE_TYPE["UNIQUE_ID"]:
             self.execution.append(currLog)
         elif currLog.type == LINE_TYPE["VARIABLE"]:
             self.execution.append(currLog)
+
+    def addToCallStack(self, logType):
+        '''
+            Add the current execution to the call stack.
+
+            - If the log is a function, add it to stack.
+            - Move down stack until parent function of current log is found
+            - Map the stack positions to find the log which called the function
+            - Add current position to stack
+            - Copy stack into global list            
+        '''
+        position = len(self.execution) - 1
+        ltInfo = self.header.getLtInfo(logType)
+        cs = self.callStack
+
+        if (ltInfo.isFunction()):
+            self.callStack.append(position)
+
+        while (len(cs) > 0):
+            currStackFuncLt = self.execution[cs[-1]].ltId
+            if (int(currStackFuncLt) == int(ltInfo.getFuncLt())):
+                break
+            cs.pop()
+
+        # Update the call stack to indicate where the functions were called from.
+        csMapped = list(map(self.getPreviousPosition, self.callStack) )
+        csMapped.append(position)
+
+        self.callStacks.append(csMapped.copy())
+    
+    def getPreviousPosition(self, position):
+        '''
+            Given a position, this function returns the previous execution
+            log type. For example, when adding to the call stack, this will
+            allow us to find the place where a function was called from.
+        '''
+        position -= 1
+        while (position >= 0):
+            if self.execution[position].type == LINE_TYPE["EXECUTION"]:
+                return position
+            position -= 1
+        return position
+        
 
 if __name__ == "__main__":
     fileName = "../sample_system_logs/job_handler.clp.zst"

--- a/application/decoder/CdlLogLine.py
+++ b/application/decoder/CdlLogLine.py
@@ -4,6 +4,7 @@ import json
 class CdlLogLine:
 
     def __init__(self, line):
+        line = line.strip()
         self.parseLine(line)
 
     def parseLine(self, line):


### PR DESCRIPTION
This PR adds support for extracting call stack information from the execution sequence of the log file. 

The call stack is a list of positions in the execution sequence of the program. It identifies the positions where the function call was made from and it also contains the current position being inspected. 

The logic works as follows:
- If the current log is a function definition, then add it to the call stack
- Starting from the top of the stack, move down until the parent function of the current log is found
- For each position in the call stack, find the position where the function was called from
- Add current position to the call stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the system's handling of execution logs to track and organize function call sequences with greater precision.
	- Improved context awareness during function execution for more effective analysis and diagnostics.
	- Added methods to manage and retrieve information from the execution call stack. 
- **Bug Fixes**
	- Improved log line processing by removing extraneous whitespace before parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->