### PR TITLE
Add support for saving unique trace events in master trace event list.

### DIFF
--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -17,7 +17,7 @@ class Cdl:
         self.exception = None
         self.traceEvents = []
         self.callStack = []
-        self.callStacks = []
+        self.callStacks = {}
 
         self.loadAndParseFile(fileName)
 
@@ -86,7 +86,7 @@ class Cdl:
         csFromCallPosition = list(map(self.getPreviousPosition, self.callStack) )
         csFromCallPosition.append(position)
 
-        self.callStacks.append(csFromCallPosition)
+        self.callStacks[position] = csFromCallPosition
     
     def getPreviousPosition(self, position):
         '''

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -51,7 +51,10 @@ class Cdl:
 
     def addTraceEvent(self, log):
         '''
-            This function adds a trace event to 
+            This function adds a trace event to the traceEvents list.
+        
+            It stores the uid, traceEvent, and position in the execution array
+            to enable retrieving unique trace stacks by processing a specific slice.
         '''
         self.traceEvents.append({
             "uid": log.uid,

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -15,7 +15,7 @@ class Cdl:
 
         self.execution = []
         self.exception = None
-        self.uniqueids = []
+        self.traceEvents = []
         self.callStack = []
         self.callStacks = []
 
@@ -30,7 +30,6 @@ class Cdl:
                 line = log_event.get_log_message()[11:].rstrip()
                 self.parseLogLine(line)
 
-
     def parseLogLine(self, line):
         '''
             Parse the log line and save the relevant data.
@@ -43,13 +42,24 @@ class Cdl:
             self.exception = currLog.value
         elif currLog.type == LINE_TYPE["EXECUTION"]:
             self.execution.append(currLog)
-            self.addToCallStack(currLog.ltId)
+            self.addToCallStack(currLog)
         elif currLog.type == LINE_TYPE["UNIQUE_ID"]:
             self.execution.append(currLog)
+            self.addTraceEvent(currLog)
         elif currLog.type == LINE_TYPE["VARIABLE"]:
             self.execution.append(currLog)
 
-    def addToCallStack(self, ltId):
+    def addTraceEvent(self, log):
+        '''
+            This function adds a trace event to 
+        '''
+        self.traceEvents.append({
+            "uid": log.uid,
+            "traceEvent": log.traceEvent,
+            "position": len(self.execution) - 1
+        })
+
+    def addToCallStack(self, log):
         '''
             Add the current execution to the call stack.
 
@@ -60,7 +70,7 @@ class Cdl:
             - Copy stack into global list            
         '''
         position = len(self.execution) - 1
-        ltInfo = self.header.getLtInfo(ltId)
+        ltInfo = self.header.getLtInfo(log.ltId)
         cs = self.callStack
 
         if (ltInfo.isFunction()):


### PR DESCRIPTION
This PR adds functionality to save the trace event information (start/end, uid, etc...) to a list. It also saves the position of the start/end of trace in the execution array. This means that when we want to get the stacks of the unique trace, we would have to process a slice of the execution array that is within the start/end positions of the unique trace.

Note: This PR makes one change that doesn't concern the title of the PR. It saves the call stacks in an object where the key is the position in the execution array. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event tracking to improve system diagnostics and monitoring.
- **Refactor**
  - Streamlined execution tracing with more structured call stack management for clearer operational insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->