### PR TITLE
Save timestamp information in execution list and in trace event list.

### DIFF
--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -11,6 +11,7 @@ class Cdl:
         '''
             Initialize the CDL reader.
         '''
+        self.fileName = fileName
         self.header = None  
 
         self.execution = []
@@ -61,7 +62,8 @@ class Cdl:
         self.traceEvents[log.uid].append({
             "traceEvent": log.traceEvent,
             "position": len(self.execution) - 1,
-            "timestamp": log.timestamp
+            "timestamp": log.timestamp,
+            "filename": self.fileName
         })
 
     def addToCallStack(self, log):

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -28,13 +28,13 @@ class Cdl:
         with ClpIrFileReader(Path(fileName)) as clp_reader:
             for log_event in clp_reader:
                 line = log_event.get_log_message()[11:].rstrip()
-                self.parseLogLine(line)
+                self.parseLogLine(log_event)
 
-    def parseLogLine(self, line):
+    def parseLogLine(self, log_event):
         '''
             Parse the log line and save the relevant data.
         '''
-        currLog = CdlLogLine(line)
+        currLog = CdlLogLine(log_event)
 
         if currLog.type == LINE_TYPE["IR_HEADER"]:
             self.header = CdlHeader(currLog.value)
@@ -59,7 +59,8 @@ class Cdl:
         self.traceEvents.append({
             "uid": log.uid,
             "traceEvent": log.traceEvent,
-            "position": len(self.execution) - 1
+            "position": len(self.execution) - 1,
+            "timestamp": log.timestamp
         })
 
     def addToCallStack(self, log):

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -27,7 +27,6 @@ class Cdl:
         '''
         with ClpIrFileReader(Path(fileName)) as clp_reader:
             for log_event in clp_reader:
-                line = log_event.get_log_message()[11:].rstrip()
                 self.parseLogLine(log_event)
 
     def parseLogLine(self, log_event):

--- a/application/decoder/Cdl.py
+++ b/application/decoder/Cdl.py
@@ -15,7 +15,7 @@ class Cdl:
 
         self.execution = []
         self.exception = None
-        self.traceEvents = []
+        self.traceEvents = {}
         self.callStack = []
         self.callStacks = {}
 
@@ -55,8 +55,10 @@ class Cdl:
             It stores the uid, traceEvent, and position in the execution array
             to enable retrieving unique trace stacks by processing a specific slice.
         '''
-        self.traceEvents.append({
-            "uid": log.uid,
+        if log.uid not in self.traceEvents:
+            self.traceEvents[log.uid] = []
+
+        self.traceEvents[log.uid].append({
             "traceEvent": log.traceEvent,
             "position": len(self.execution) - 1,
             "timestamp": log.timestamp

--- a/application/decoder/CdlLogLine.py
+++ b/application/decoder/CdlLogLine.py
@@ -3,8 +3,11 @@ import json
 
 class CdlLogLine:
 
-    def __init__(self, line):
-        line = line.strip()
+    def __init__(self, log_event):
+        self.timestamp = log_event.get_timestamp()
+
+        # TODO: Improve the way this is implemented.
+        line = log_event.get_log_message()[11:].strip()
         self.parseLine(line)
 
     def parseLine(self, line):


### PR DESCRIPTION
This PR adds timestamp information to the execution list and to the trace event list. This information will be used to assemble the unique traces across programs in the system and when performing queries.

This PR also makes one unrelated change, it saves the unique trace information in an object instead of a list. The key is the unique id and the list contains the trace events. It also saves the file name to the trace event object. This information will become relevant when the higher level code parses it to assemble the unique trace across the system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced log event processing to capture complete event details.
	- Improved trace logging with accurate timestamp data for better activity tracking.
	- Updated method signatures for better clarity and functionality in log processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->