### PR TITLE
Use logFileName instead of programName as key for UID level trace info (fixes #15).

### DIFF
--- a/application/system_processor/decoder/Cdl.py
+++ b/application/system_processor/decoder/Cdl.py
@@ -85,7 +85,7 @@ class Cdl:
             self.uniqueTraceEvents[uid] = []        
         
         self.uniqueTraceEvents[uid].append({
-            "programName": self.logFileName.split(".")[0] + ".py",
+            "logFileName": self.logFileName,
             "trace": trace,
             "timestamp": self.execution[startPos].timestamp
         })


### PR DESCRIPTION
In PR https://github.com/vishalpalaniappan/asp-query-server/pull/14, the program name was added to the trace info but this information was not saved in the Cdl class. So when ASV requests more information for a program, the system processor does not know which CDL instance to read. I think it is better to save it as logFileName for now and revisit defining programs in the future.

```
uniqueTraceEvents[uid] = {
    "logFileName": <logFileName>
    "timestamp": <ts>
    "trace": [
                {
                     "position": <pos>,
                      "level": <level>,
                      "name":  <name>,
                      "lineNo": <lineno>,
                      "file":  <file> 
                }
                ...
      ]
}
```
## Validation Performed
Ran server, connected with ASV and verified that the relevant information was included in the received message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced diagnostic tracking by recording log file information more directly, improving the accuracy and simplicity of event tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->