### PR TITLE
Add debugger class and move decoder functions to its own class.

### DIFF
--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -43,7 +43,7 @@ class Cdl:
         '''
         cs = self.decoder.callStacks[position]
         if len(cs) <= 1:
-            return
+            return None
         return self.goToPosition(cs[-2])
 
     def stepOverForward(self, position):
@@ -56,7 +56,7 @@ class Cdl:
             position = self.decoder.getNextExecutionPosition(position)
 
             if position is None:
-                return
+                return None
             
             if len(self.decoder.callStacks[position]) <= originalStackSize:
                 break
@@ -72,8 +72,8 @@ class Cdl:
         while position > 0:
             position = self.decoder.getPreviousExecutionPosition(position)
 
-            if position == None:
-                return
+            if position is None:
+                return None
             
             if len(self.decoder.callStacks[position]) <= originalStackSize:
                 break

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -33,7 +33,9 @@ class Cdl:
         '''
         nextPosition = self.decoder.getNextExecutionPosition(position)
         if nextPosition:
-            self.goToPosition(nextPosition)
+            return self.goToPosition(nextPosition)
+        
+        return None
 
     def stepOut(self, position):
         '''
@@ -42,7 +44,7 @@ class Cdl:
         cs = self.decoder.callStacks[position]
         if len(cs) <= 1:
             return
-        self.goToPosition(cs[-2])
+        return self.goToPosition(cs[-2])
 
     def stepOverForward(self, position):
         '''
@@ -53,13 +55,13 @@ class Cdl:
         while position < len(self.decoder.execution):
             position = self.decoder.getNextExecutionPosition(position)
 
-            if position == None:
+            if position is None:
                 return
             
             if len(self.decoder.callStacks[position]) <= originalStackSize:
                 break
         
-        self.goToPosition(position)
+        return self.goToPosition(position)
     
     def stepOverBackward(self, position):
         '''
@@ -76,16 +78,16 @@ class Cdl:
             if len(self.decoder.callStacks[position]) <= originalStackSize:
                 break
         
-        self.goToPosition(position)
+        return self.goToPosition(position)
 
     def goToStart(self):
         '''
             Go to the first executed line in the file.
         '''
-        self.goToPosition(0)
+        return self.goToPosition(0)
 
     def goToEnd(self):
         '''
             Go to the last executed line in the file.
         '''
-        self.goToPosition(self.decoder.lastExecution)
+        return self.goToPosition(self.decoder.lastExecution)

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -6,4 +6,27 @@ class Cdl:
     def __init__(self, filePath):
         self.logFileName = os.path.basename(filePath)
         self.decoder = CdlDecoder(filePath)
+
+    def goToPosition(self, position):
+        pass
+
+    def getCallStackAtPosition(self, position):
+        pass
+
+    def stepInto(self):
+        pass
+
+    def stepOut(self):
+        pass
+
+    def stepOverForward(self):
+        pass
     
+    def stepOverBackward(self):
+        pass
+
+    def goToStart(self):
+        pass
+
+    def goToEnd(self):
+        pass

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -4,6 +4,7 @@ import os
 class Cdl:
 
     def __init__(self, filePath):
+        self.filePath = filePath
         self.logFileName = os.path.basename(filePath)
         self.decoder = CdlDecoder(filePath)
 

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -10,8 +10,6 @@ class Cdl:
 
         self.goToPosition(self.decoder.lastExecution)
 
-        self.stepOverBackward(self.decoder.lastExecution)
-
     def uniqueTraceEvents(self):
         '''
             Return the unique traces in the log file
@@ -26,7 +24,7 @@ class Cdl:
             Go to the given position
         '''
         callStack = self.decoder.getCallStackAtPosition(position)
-        print(callStack)
+        self.position = position
         return callStack
 
     def stepInto(self, position):
@@ -68,7 +66,7 @@ class Cdl:
         '''
         originalStackSize = len(self.decoder.callStacks[position])
 
-        while position < len(self.decoder.execution):
+        while position > 0:
             position = self.decoder.getPreviousExecutionPosition(position)
 
             if position == None:

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -8,32 +8,85 @@ class Cdl:
         self.logFileName = os.path.basename(filePath)
         self.decoder = CdlDecoder(filePath)
 
-        self.decoder.getCallStackAtPosition(self.decoder.lastExecution)
+        self.goToPosition(self.decoder.lastExecution)
+
+        self.stepOverBackward(self.decoder.lastExecution)
 
     def uniqueTraceEvents(self):
+        '''
+            Return the unique traces in the log file
+        '''
         return self.decoder.uniqueTraceEvents
     
     def getFileTree(self):
         return self.decoder.header.fileTree
 
     def goToPosition(self, position):
-        callStack = self.decoder.getCallStackAtPosition[position]
+        '''
+            Go to the given position
+        '''
+        callStack = self.decoder.getCallStackAtPosition(position)
+        print(callStack)
         return callStack
 
-    def stepInto(self):
-        pass
+    def stepInto(self, position):
+        '''
+            Step into the current position
+        '''
+        nextPosition = self.decoder.getNextExecutionPosition(position)
+        self.goToPosition(nextPosition)
 
-    def stepOut(self):
-        pass
+    def stepOut(self, position):
+        '''
+            Step out of the current position
+        '''
+        cs = self.decoder.callStacks[position]
+        if len(cs) <= 1:
+            return
+        self.goToPosition(cs[-2])
 
-    def stepOverForward(self):
-        pass
+    def stepOverForward(self, position):
+        '''
+            Step over function call forwards
+        '''
+        originalStackSize = len(self.decoder.callStacks[position])
+
+        while position < len(self.decoder.execution):
+            position = self.decoder.getNextExecutionPosition(position)
+
+            if position == None:
+                return
+            
+            if len(self.decoder.callStacks[position]) <= originalStackSize:
+                break
+        
+        self.goToPosition(position)
     
-    def stepOverBackward(self):
-        pass
+    def stepOverBackward(self, position):
+        '''
+            Step over function calls backwards
+        '''
+        originalStackSize = len(self.decoder.callStacks[position])
+
+        while position < len(self.decoder.execution):
+            position = self.decoder.getPreviousExecutionPosition(position)
+
+            if position == None:
+                return
+            
+            if len(self.decoder.callStacks[position]) <= originalStackSize:
+                break
+        
+        self.goToPosition(position)
 
     def goToStart(self):
-        pass
+        '''
+            Go to the first executed line in the file.
+        '''
+        self.goToPosition(0)
 
     def goToEnd(self):
-        pass
+        '''
+            Go to the last executed line in the file.
+        '''
+        self.goToPosition(self.decoder.lastExecution)

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -32,7 +32,8 @@ class Cdl:
             Step into the current position
         '''
         nextPosition = self.decoder.getNextExecutionPosition(position)
-        self.goToPosition(nextPosition)
+        if nextPosition:
+            self.goToPosition(nextPosition)
 
     def stepOut(self, position):
         '''

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -8,6 +8,8 @@ class Cdl:
         self.logFileName = os.path.basename(filePath)
         self.decoder = CdlDecoder(filePath)
 
+        self.decoder.getCallStackAtPosition(self.decoder.lastExecution)
+
     def uniqueTraceEvents(self):
         return self.decoder.uniqueTraceEvents
     
@@ -15,10 +17,8 @@ class Cdl:
         return self.decoder.header.fileTree
 
     def goToPosition(self, position):
-        pass
-
-    def getCallStackAtPosition(self, position):
-        pass
+        callStack = self.decoder.getCallStackAtPosition[position]
+        return callStack
 
     def stepInto(self):
         pass

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -7,6 +7,12 @@ class Cdl:
         self.logFileName = os.path.basename(filePath)
         self.decoder = CdlDecoder(filePath)
 
+    def uniqueTraceEvents(self):
+        return self.decoder.uniqueTraceEvents
+    
+    def getFileTree(self):
+        return self.decoder.header.fileTree
+
     def goToPosition(self, position):
         pass
 

--- a/application/system_processor/Cdl.py
+++ b/application/system_processor/Cdl.py
@@ -1,0 +1,9 @@
+from application.system_processor.decoder.CdlDecoder import CdlDecoder
+import os
+
+class Cdl:
+
+    def __init__(self, filePath):
+        self.logFileName = os.path.basename(filePath)
+        self.decoder = CdlDecoder(filePath)
+    

--- a/application/system_processor/SystemProcessor.py
+++ b/application/system_processor/SystemProcessor.py
@@ -23,7 +23,7 @@ class SystemProcessor:
         for logFileName in files:
             if logFileName.endswith(".clp.zst"):
                 cdlFile = Cdl(os.path.join(self.logFolder, logFileName))
-                self.addUniqueTraceEvents(cdlFile.decoder.uniqueTraceEvents)
+                self.addUniqueTraceEvents(cdlFile.uniqueTraceEvents())
                 self.logFiles.append(cdlFile)
         
         # Sort the trace events by timestamp
@@ -50,7 +50,7 @@ class SystemProcessor:
         '''
         fileTrees = {}
         for log in self.logFiles:
-            fileTrees[log.logFileName] = log.decoder.header.fileTree
+            fileTrees[log.logFileName] = log.getFileTree()
 
         return fileTrees
 

--- a/application/system_processor/SystemProcessor.py
+++ b/application/system_processor/SystemProcessor.py
@@ -1,5 +1,5 @@
 import os
-from application.system_processor.decoder.Cdl import Cdl
+from application.system_processor.Cdl import Cdl
 import json
 
 class SystemProcessor:
@@ -22,9 +22,8 @@ class SystemProcessor:
 
         for logFileName in files:
             if logFileName.endswith(".clp.zst"):
-                _path = os.path.join(self.logFolder, logFileName)
-                cdlFile = Cdl(logFileName, _path)
-                self.addUniqueTraceEvents(cdlFile.uniqueTraceEvents)
+                cdlFile = Cdl(os.path.join(self.logFolder, logFileName))
+                self.addUniqueTraceEvents(cdlFile.decoder.uniqueTraceEvents)
                 self.logFiles.append(cdlFile)
         
         # Sort the trace events by timestamp
@@ -51,7 +50,7 @@ class SystemProcessor:
         '''
         fileTrees = {}
         for log in self.logFiles:
-            fileTrees[log.logFileName] = log.header.fileTree
+            fileTrees[log.logFileName] = log.decoder.header.fileTree
 
         return fileTrees
 

--- a/application/system_processor/decoder/CdlDecoder.py
+++ b/application/system_processor/decoder/CdlDecoder.py
@@ -129,24 +129,35 @@ class CdlDecoder:
                 self.addUniqueTrace(popped["uid"], popped["position"], position)
                 
         # Update the call stack to indicate where the functions were called from.
-        csFromCallPosition = list(map(self.getPreviousExecutionPosition, self.callStack))
+        csFromCallPosition = []
+        for cs in self.callStack:
+            csFromCallPosition.append(self.getPreviousExecutionPosition(cs["position"]))
         csFromCallPosition.append(position)
 
         self.callStacks[position] = csFromCallPosition
     
-    def getPreviousExecutionPosition(self, cs):
+    def getPreviousExecutionPosition(self, position):
         '''
-            Given a position, this function returns the previous execution
-            log type. For example, when adding to the call stack, this will
+            This function returns the previous execution log type. 
+            For example, when adding to the call stack, this will
             allow us to find the place where a function was called from.
         '''
-        position = cs["position"]
-        position -= 1
-        while (position >= 0):
+        while (position >= 1):
+            position -= 1
             if self.execution[position].type == LINE_TYPE["EXECUTION"]:
                 return position
-            position -= 1
-        return position
+        return None
+    
+
+    def getNextExecutionPosition(self, position):
+        '''
+            This function returns the next execution log type. 
+        '''
+        while (position < len(self.execution) - 2):
+            position += 1
+            if self.execution[position].type == LINE_TYPE["EXECUTION"]:
+                return position
+        return None
     
     def getCallStackAtPosition(self, position):
         '''
@@ -169,4 +180,6 @@ class CdlDecoder:
                 "position": cs,
                 "lineNumber": ltInfo.getLineNo()
             })
+
+        return csInfo
 

--- a/application/system_processor/decoder/CdlDecoder.py
+++ b/application/system_processor/decoder/CdlDecoder.py
@@ -4,13 +4,15 @@ from application.system_processor.decoder.CDL_CONSTANTS import LINE_TYPE
 from application.system_processor.decoder.CdlLogLine import CdlLogLine
 from application.system_processor.decoder.CdlHeader import CdlHeader
 
-class Cdl:
+import os
 
-    def __init__(self, logFileName, filePath):
+class CdlDecoder:
+
+    def __init__(self, filePath):
         '''
             Initialize the CDL reader.
         '''
-        self.logFileName = logFileName
+        self.logFileName = os.path.basename(filePath)
         self.filePath = filePath
         self.header = None  
 

--- a/application/system_processor/decoder/CdlDecoder.py
+++ b/application/system_processor/decoder/CdlDecoder.py
@@ -153,10 +153,11 @@ class CdlDecoder:
         '''
             This function returns the next execution position. 
         '''
-        while (position < len(self.execution) - 2):
-            position += 1
+        position += 1
+        while (position < len(self.execution)):
             if self.execution[position].type == LINE_TYPE["EXECUTION"]:
                 return position
+            position += 1
         return None
     
     def getCallStackAtPosition(self, position):

--- a/application/system_processor/decoder/CdlDecoder.py
+++ b/application/system_processor/decoder/CdlDecoder.py
@@ -138,7 +138,7 @@ class CdlDecoder:
     
     def getPreviousExecutionPosition(self, position):
         '''
-            This function returns the previous execution log type. 
+            This function returns the previous execution position. 
             For example, when adding to the call stack, this will
             allow us to find the place where a function was called from.
         '''
@@ -151,7 +151,7 @@ class CdlDecoder:
 
     def getNextExecutionPosition(self, position):
         '''
-            This function returns the next execution log type. 
+            This function returns the next execution position. 
         '''
         while (position < len(self.execution) - 2):
             position += 1

--- a/application/system_processor/decoder/CdlDecoder.py
+++ b/application/system_processor/decoder/CdlDecoder.py
@@ -30,6 +30,7 @@ class CdlDecoder:
         '''
         with ClpIrFileReader(Path(filePath)) as clp_reader:
             for log_event in clp_reader:
+                self.position = 0
                 self.parseLogLine(log_event)
 
     def parseLogLine(self, log_event):
@@ -43,9 +44,12 @@ class CdlDecoder:
         elif currLog.type == LINE_TYPE["EXCEPTION"]:
             self.exception = currLog.value
         elif currLog.type == LINE_TYPE["EXECUTION"]:
+            self.position += 1
             self.execution.append(currLog)
+            self.lastExecution = self.position
             self.addToCallStack(currLog)
         elif currLog.type == LINE_TYPE["VARIABLE"]:
+            self.position += 1
             self.execution.append(currLog)
             self.saveUniqueId(currLog)
 
@@ -143,8 +147,3 @@ class CdlDecoder:
                 return position
             position -= 1
         return position
-        
-
-if __name__ == "__main__":
-    fileName = "../sample_system_logs/job_handler.clp.zst"
-    f = Cdl(fileName)

--- a/application/system_processor/decoder/CdlHeader.py
+++ b/application/system_processor/decoder/CdlHeader.py
@@ -20,10 +20,10 @@ class CdlHeader:
         self.fileTree = header["fileTree"]
 
         for lt in header["ltMap"]:
-            self.ltMap[lt] = LogType(header["ltMap"][lt])
+            self.ltMap[int(lt)] = LogType(header["ltMap"][lt])
         
         for lt in header["varMap"]:
-            self.varMap[lt] = Variable(header["varMap"][lt])
+            self.varMap[int(lt)] = Variable(header["varMap"][lt])
 
 
     def getLtInfo(self, logtype):

--- a/application/system_processor/decoder/CdlLogLine.py
+++ b/application/system_processor/decoder/CdlLogLine.py
@@ -52,7 +52,7 @@ class CdlLogLine:
         split = line.split()
 
         self.type = LINE_TYPE["VARIABLE"]
-        self.varId = split[1]
+        self.varId = int(split[1])
         self.value = self.parseIfJson("".join(split[2:]))
 
     def parseExecution(self, line):
@@ -61,7 +61,7 @@ class CdlLogLine:
             "<logtypeid>"
         '''
         self.type = LINE_TYPE["EXECUTION"]
-        self.ltId = line
+        self.ltId = int(line)
 
 
     def parseIfJson(self, value):

--- a/application/system_processor/decoder/LogType.py
+++ b/application/system_processor/decoder/LogType.py
@@ -8,26 +8,22 @@ class LogType:
             setattr(self, key, ltInfo[key])
 
     def getLt(self):
-        return getattr(self, "id")
+        return getattr(self, "id", None)
     
     def getFuncLt(self):
-        return getattr(self, "funcid")
+        return getattr(self, "funcid", None)
     
     def getType(self):
-        return getattr(self, "type")
+        return getattr(self, "type", None)
 
     def isFunction(self):
-        return getattr(self, "type") == "function"
+        return getattr(self, "type", None) == "function"
     
     def isUnique(self):
-        return getattr(self, "isUnique")
+        return getattr(self, "isUnique", None)
     
     def getLineNo(self):
-        return getattr(self, "lineno")
+        return getattr(self, "lineno", None)
         
     def getName(self):
-        if hasattr(self, "name"):
-            return self.name
-        else:
-            return None
-
+        return getattr(self, "name", None)

--- a/application/system_processor/decoder/LogType.py
+++ b/application/system_processor/decoder/LogType.py
@@ -27,7 +27,7 @@ class LogType:
         
     def getName(self):
         if hasattr(self, "name"):
-            return getattr(self, "name")
+            return self.name
         else:
-            None
+            return None
 

--- a/application/system_processor/decoder/LogType.py
+++ b/application/system_processor/decoder/LogType.py
@@ -21,7 +21,13 @@ class LogType:
     
     def isUnique(self):
         return getattr(self, "isUnique")
+    
+    def getLineNo(self):
+        return getattr(self, "lineno")
         
     def getName(self):
-        return getattr(self, "name")
+        if hasattr(self, "name"):
+            return getattr(self, "name")
+        else:
+            None
 

--- a/application/system_processor/decoder/Variable.py
+++ b/application/system_processor/decoder/Variable.py
@@ -8,13 +8,13 @@ class Variable:
             setattr(self, key, varInfo[key])
 
     def getName(self):
-        return getattr(self, "name")
+        return getattr(self, "name", None)
     
     def getFuncLt(self):
-        return getattr(self, "funcid")
+        return getattr(self, "funcid", None)
     
     def isTempVar(self):
-        return getattr(self, "isTemp")
+        return getattr(self, "isTemp", None)
     
     def isGlobal(self):
-        return getattr(self, "global")
+        return getattr(self, "global", None)


### PR DESCRIPTION
This PR moves the cdl decoder functions into a new class named CdlDecoder. It redefines the Cdl class to include the debugger functionality such as:

- Get call stack at position
- Step Into
- Step out
- Stop Over Forwards
- Step Over Backwards 
- Go to start
- Go to end

Note: Variable extraction will be added in the next PR. 

## Implementation

### Get Call Stack
When parsing the CDL file, the call stack is assembled as functions are visited. The logic works as follows:
- If current execution is a function definition, add it to the call stack.
- Move down the call stack while removing calls until the parent function of the current execution is found.
- Add current position to the call stack. 
- Update call stack list to refer to the execution position where the function was called from.
- Save call stack to global list.

### Step Over Forwards
To step over a function call forward, the call stack is used. More specifically, the current call stack size is saved. Then the next execution position is found and the call stack for that position is loaded. This process is repeated until the call stack size is the same or lower than the current position.

### Step Over Backwards
To step over a function call backward, the call stack is used. More specifically, the current call stack size is saved. Then the the previous execution position is found and the call stack for that position is loaded. This process is repeated until the call stack size is the same or lower than the current position.

### Step Into
Stepping into the next position has relatively simple logic. It simply finds the next execution position and goes to it. If the next position was not found, then we have reached the end of the file. 

### Step Out
Stepping out of the current function has simply logic. It simply moves down to the call stack position before the current one.

### Go to start
Go to the first execution position. This will be zero because the first non-header log statement will be a log type log of the first executed instruction. If this were to change, the logic would have to be updated to find the first execution position. 

### Go to end
Go to the last execution position. When building the CDL file, the last execution log statement that was processed is saved continuously. This value is used to get the last execution position in the file. 

## Validation Performed

Loaded sample CDL file in the diagnostic log viewer and in the system processor. Performed each debugger operation and verified that the expected position was loaded. 

The debugger operations in the diagnostic log viewer were previously verified using debugger operations in VSCode.

[sample.zip](https://github.com/user-attachments/files/19569284/sample.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new log-processing component that streamlines initialization with a single file path.
  - Added methods to retrieve line numbers from log types and to access call stack details for improved data handling.

- **Bug Fixes**
  - Improved the handling of variable and execution IDs by ensuring they are stored as integers.
  - Enhanced robustness of methods to prevent errors when accessing non-existent attributes.

- **Refactor**
  - Updated system log parsing to consistently retrieve trace events and file tree information.
  - Enhanced the handling of keys in mappings to use integers for better data access.
  - Reorganized the underlying module structure to enhance clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->